### PR TITLE
feat: 루비콘 개발자가 아닌 경우에도 슬랙 메세지에 github 유저명이 노출되도록 수정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @evan-moon @pa-rang @devGw
+* @evan-moon @pa-rang @devGW

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @evan-moon @s-ong-c @shinsunyoung
+* @evan-moon @pa-rang @devGw

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,16 @@
+name: PR Slack Notification
+on: [pull_request, pull_request_review, pull_request_review_comment]
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    name: Run
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Fire Notification
+        uses: Lubycon/github-reviewer-slack-noti-action@v1.3.0
+        with:
+          slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
+          channel-id: C01SSJ6HGTH

--- a/src/models/developer.ts
+++ b/src/models/developer.ts
@@ -2,4 +2,5 @@ export interface Developer {
   name: string;
   githubUserName: string;
   slackUserId: string;
+  isExternalUser?: true;
 }

--- a/src/utils/github/pullRequests.ts
+++ b/src/utils/github/pullRequests.ts
@@ -8,20 +8,14 @@ import {
   GithubPullRequestComment,
   RawGithubPullRequestComment,
 } from 'models/github';
-import { fetchDevelopers, findDeveloperByGithubUser } from 'utils/user';
+import { fetchDevelopers, getDeveloperByGithubUser } from 'utils/user';
 import { getCodeOwners, getRepositoryName } from './repositories';
 
 export async function getPullRequestOwner() {
   const { pull_request } = github.context.payload;
   const developers = await fetchDevelopers();
   const owner = pull_request?.user as RawGithubUser;
-  return (
-    findDeveloperByGithubUser(developers, owner.login) ?? {
-      name: owner.login,
-      slackUserId: '',
-      githubUserName: owner.login,
-    }
-  );
+  return getDeveloperByGithubUser(developers, owner.login);
 }
 
 export async function getAssignedPullRequestReviewers() {
@@ -33,7 +27,7 @@ export async function getAssignedPullRequestReviewers() {
   const reviewers = codeOwners.length > 0 ? codeOwners : prReviewers.map(reviewer => reviewer.login);
 
   return reviewers
-    .map(user => findDeveloperByGithubUser(developers, user))
+    .map(user => getDeveloperByGithubUser(developers, user))
     .filter<Developer>((user): user is Developer => user != null);
 }
 
@@ -48,13 +42,7 @@ export function getRawPullRequestComment() {
 export async function getDeveloperFromGithubUser(user: RawGithubUser) {
   const developers = await fetchDevelopers();
   const rawGithubUserName = user.login;
-  return (
-    findDeveloperByGithubUser(developers, rawGithubUserName) ?? {
-      name: rawGithubUserName,
-      slackUserId: '',
-      githubUserName: rawGithubUserName,
-    }
-  );
+  return getDeveloperByGithubUser(developers, rawGithubUserName);
 }
 
 export async function getPullRequest(): Promise<GithubPullRequest> {

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -7,7 +7,7 @@ import { replaceGithubUserToSlackUserInString } from './user';
 const slackClient = new WebClient(SLACK_BOT_TOKEN);
 
 export function createSlackMention(developer: Developer) {
-  return `<@${developer.slackUserId}>`;
+  return developer.isExternalUser === true ? developer.githubUserName : `<@${developer.slackUserId}>`;
 }
 
 export function sendMessage(args: ChatPostMessageArguments) {

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -7,8 +7,15 @@ export async function fetchDevelopers(): Promise<Developer[]> {
   return response.json();
 }
 
-export function findDeveloperByGithubUser(developers: Developer[], githubUserName: string) {
-  return developers.find(user => user.githubUserName === githubUserName);
+export function getDeveloperByGithubUser(developers: Developer[], githubUserName: string) {
+  return (
+    developers.find(user => user.githubUserName === githubUserName) ?? {
+      name: githubUserName,
+      githubUserName: githubUserName,
+      slackUserId: githubUserName,
+      isExternalUser: true,
+    }
+  );
 }
 
 export function hasMentionInMessage(message: string) {
@@ -23,7 +30,7 @@ export async function replaceGithubUserToSlackUserInString(message: string) {
   return words
     .map(message => {
       const githubUser = message.replace('@', '');
-      const developer = findDeveloperByGithubUser(developers, githubUser);
+      const developer = getDeveloperByGithubUser(developers, githubUser);
 
       return developer == null ? message : createSlackMention(developer);
     })


### PR DESCRIPTION
<img width="588" alt="스크린샷 2021-07-12 오후 4 16 00" src="https://user-images.githubusercontent.com/19145342/125246214-74a57a00-e32c-11eb-88c2-a94c02c218b1.png">

요런 경우에도 해당 사용자의 깃허브 유저 네임이 메세지에 담길 수 있도록 변경합니다.