### PR TITLE
feat: Mattermost Incoming Webhook PoC를 위한 메시지 함수들 추가

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,5 +1,5 @@
 name: PR Slack Notification
-on: [pull_request, pull_request_review, pull_request_review_comment]
+# on: [pull_request, pull_request_review, pull_request_review_comment]
 
 jobs:
   create-pull-request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
           slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
           channel-id: C01UXTP3P4P
-          mattermost-host: https://mattermost.lubycon.io/hooks/5hhnw68dsbg6uyxx4tmgdds7jo
+          mattermost-host: https://mattermost.lubycon.io/hooks/bj5zk9se6fd5iy63csoefbr64c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,4 @@ jobs:
           slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
           channel-id: C01UXTP3P4P
+          mattermost-host: https://mattermost.lubycon.io/hooks/5hhnw68dsbg6uyxx4tmgdds7jo

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "ts-node ./index.ts",
     "release": "semantic-release",
-    "build": "ncc build --source-map --license licenses.txt"
+    "build": "ncc build --source-map --license licenses.txt",
+    "test:mattermost": "ts-node ./test/mattermost.ts"
   },
   "author": "",
   "license": "UNLICENSED",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,14 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { SUPPROTED_EVENTS } from 'constants/github';
 import {
-  sendSlackGithubPullRequestCommentMessage,
-  sendSlackMessagePullRequestReviewMessage,
-  sendSlackMessageReviewApprovedMessage,
+  sendReviewApprovedSlackMessage,
+  sendPullRequestReviewSlackMessage,
+  sendPullRequestCommentSlackMessage,
 } from 'utils/slack';
 import {
-  sendMattermostMessagePullRequestReviewMessage,
-  sendMattermostMessageReviewApprovedMessage,
+  sendPullRequestReviewMattermostMessage,
+  sendReviewApprovedMattermostMessage,
+  sendPullRequestCommentMattermostMessage,
 } from 'utils/mattermost';
 import { getPullRequest, getPullRequestComment, getPullRequestReview } from 'utils/github/pullRequests';
 import { parseGithubEvent } from 'utils/github/events';
@@ -38,20 +39,20 @@ async function main() {
   switch (githubEvent.type) {
     case GithubActionEventName.PR열림: {
       core.info('Pull Request 오픈이 감지되었습니다. 슬랙 메세지를 보냅니다.');
-      await sendSlackMessagePullRequestReviewMessage(pullRequest);
+      await sendPullRequestReviewSlackMessage(pullRequest);
       if (MATTERMOST_HOST != null) {
         // PoC...
-        await sendMattermostMessagePullRequestReviewMessage(pullRequest);
+        await sendPullRequestReviewMattermostMessage(pullRequest);
       }
       break;
     }
     case GithubActionEventName.PR머지승인: {
       core.info('Pull Request 승인이 감지되었습니다. 슬랙 메세지를 보냅니다.');
       const review = await getPullRequestReview();
-      await sendSlackMessageReviewApprovedMessage({ pullRequest, review });
+      await sendReviewApprovedSlackMessage({ pullRequest, review });
       if (MATTERMOST_HOST != null) {
         // PoC...
-        await sendMattermostMessageReviewApprovedMessage({ pullRequest, review });
+        await sendReviewApprovedMattermostMessage({ pullRequest, review });
       }
       break;
     }
@@ -60,7 +61,11 @@ async function main() {
 
       if (hasMentionInMessage(comment.message)) {
         core.info('Pull Request에 멘션이 포함된 새로운 댓글이 감지되었습니다. 슬랙 메세지를 보냅니다.');
-        await sendSlackGithubPullRequestCommentMessage({ pullRequest, comment });
+        await sendPullRequestCommentSlackMessage({ pullRequest, comment });
+        if (MATTERMOST_HOST != null) {
+          // PoC...
+          await sendPullRequestCommentMattermostMessage({ pullRequest, comment });
+        }
       }
 
       break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,19 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { SUPPROTED_EVENTS } from 'constants/github';
 import {
-  sendGithubPullRequestCommentMessage,
-  sendMessagePullRequestReviewMessage,
-  sendMessageReviewApprovedMessage,
+  sendSlackGithubPullRequestCommentMessage,
+  sendSlackMessagePullRequestReviewMessage,
+  sendSlackMessageReviewApprovedMessage,
 } from 'utils/slack';
+import {
+  sendMattermostMessagePullRequestReviewMessage,
+  sendMattermostMessageReviewApprovedMessage,
+} from 'utils/mattermost';
 import { getPullRequest, getPullRequestComment, getPullRequestReview } from 'utils/github/pullRequests';
 import { parseGithubEvent } from 'utils/github/events';
 import { GithubActionEventName } from 'models/github';
 import { hasMentionInMessage } from 'utils/user';
+import { MATTERMOST_HOST } from 'utils/input';
 
 const { eventName, payload } = github.context;
 
@@ -33,13 +38,21 @@ async function main() {
   switch (githubEvent.type) {
     case GithubActionEventName.PR열림: {
       core.info('Pull Request 오픈이 감지되었습니다. 슬랙 메세지를 보냅니다.');
-      await sendMessagePullRequestReviewMessage(pullRequest);
+      await sendSlackMessagePullRequestReviewMessage(pullRequest);
+      if (MATTERMOST_HOST != null) {
+        // PoC...
+        await sendMattermostMessagePullRequestReviewMessage(pullRequest);
+      }
       break;
     }
     case GithubActionEventName.PR머지승인: {
       core.info('Pull Request 승인이 감지되었습니다. 슬랙 메세지를 보냅니다.');
       const review = await getPullRequestReview();
-      await sendMessageReviewApprovedMessage({ pullRequest, review });
+      await sendSlackMessageReviewApprovedMessage({ pullRequest, review });
+      if (MATTERMOST_HOST != null) {
+        // PoC...
+        await sendMattermostMessageReviewApprovedMessage({ pullRequest, review });
+      }
       break;
     }
     case GithubActionEventName.PR리뷰코멘트: {
@@ -47,7 +60,7 @@ async function main() {
 
       if (hasMentionInMessage(comment.message)) {
         core.info('Pull Request에 멘션이 포함된 새로운 댓글이 감지되었습니다. 슬랙 메세지를 보냅니다.');
-        await sendGithubPullRequestCommentMessage({ pullRequest, comment });
+        await sendSlackGithubPullRequestCommentMessage({ pullRequest, comment });
       }
 
       break;

--- a/src/models/developer.ts
+++ b/src/models/developer.ts
@@ -3,4 +3,5 @@ export interface Developer {
   githubUserName: string;
   slackUserId: string;
   isExternalUser?: true;
+  mattermostUserName?: string;
 }

--- a/src/models/mattermost.ts
+++ b/src/models/mattermost.ts
@@ -1,0 +1,51 @@
+/**
+ * https://docs.mattermost.com/developer/interactive-messages.html
+ */
+interface MattermostMessageAttachmentAction {
+  id: string;
+  name: string;
+  integration: {
+    url: string;
+    context?: {
+      action: string;
+    };
+  };
+}
+
+interface MattermostMessageAttachmentFields {
+  title: string;
+  value: string;
+  short?: boolean;
+}
+
+/**
+ * https://docs.mattermost.com/developer/message-attachments.html
+ */
+export interface MattermostMessageAttachment {
+  pretext?: string;
+  text?: string;
+  actions?: MattermostMessageAttachmentAction[];
+  color?: string;
+  fallback: string;
+  author_name?: string;
+  author_link?: string;
+  author_icon?: string;
+  title?: string;
+  title_link?: string;
+  fields?: MattermostMessageAttachmentFields[];
+  image_url?: string;
+  thumb_url?: string;
+}
+
+/**
+ * https://developers.mattermost.com/integrate/incoming-webhooks/
+ */
+export interface MattermostMessageParams {
+  text?: string;
+  channel?: string;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
+  attachments?: MattermostMessageAttachment[];
+  type?: string;
+}

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -3,3 +3,4 @@ import * as core from '@actions/core';
 export const SLACK_BOT_TOKEN = core.getInput('slack-bot-token');
 export const TARGET_SLACK_CHANNEL_ID = core.getInput('channel-id');
 export const GITHUB_TOKEN = core.getInput('github-token');
+export const MATTERMOST_HOST = core.getInput('mattermost-host');

--- a/src/utils/mattermost.ts
+++ b/src/utils/mattermost.ts
@@ -1,13 +1,14 @@
 import fetch from 'node-fetch';
 import { MATTERMOST_HOST } from './input';
-import { Developer } from '../models/developer';
-import { GithubPullRequest, GithubPullRequestReview } from '../models/github';
+import { Developer } from 'models/developer';
+import { GithubPullRequest, GithubPullRequestComment, GithubPullRequestReview } from 'models/github';
 import { MattermostMessageAttachment, MattermostMessageParams } from 'models/mattermost';
+import { replaceGithubUserToMattermostUserInString } from '../utils/user';
 
 export function createMattermostMention(developer: Developer) {
   return developer.isExternalUser === true
     ? developer.githubUserName
-    : `<@${developer.mattermostUserName ?? developer.githubUserName}>`;
+    : `@${developer.mattermostUserName ?? developer.githubUserName}`;
 }
 
 export function sendMessage(args: MattermostMessageParams) {
@@ -17,45 +18,36 @@ export function sendMessage(args: MattermostMessageParams) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      text: args.text,
+      username: 'PR 봇',
+      icon_url: 'https://assets.lubycon.io/logo/symbol-color.svg',
+      ...args,
     }),
   });
 }
 
-export function sendMattermostMessageReviewApprovedMessage({
+export function sendReviewApprovedMattermostMessage({
   pullRequest: { repository, link, title, owner },
   review: { author },
 }: {
   pullRequest: GithubPullRequest;
   review: GithubPullRequestReview;
 }) {
+  const text = `*${repository}* < [${title}](${link})\n\n---\n\n${createMattermostMention(
+    author
+  )}님이 ${createMattermostMention(
+    owner
+  )}님의 Pull Request를 승인했어요. 이제 머지하러가볼까요?\n\n[머지하러가기 :partymerge:](${link})`;
+
   const attachments: MattermostMessageAttachment = {
     fallback: `${repository}의 Pull Request가 승인되었어요.`,
     title: 'Pull Request가 승인되었어요! :white_check_mark:',
-    text: `
-      *${repository}* < [${title}](${link})
-
-      ---
-
-      ${createMattermostMention(author)}님이 ${createMattermostMention(
-      owner
-    )}님의 Pull Request를 승인했어요. 이제 머지하러가볼까요?
-    `,
-    actions: [
-      {
-        id: 'mergePullRequest',
-        name: '머지하러가기 :partymerge:',
-        integration: {
-          url: link,
-        },
-      },
-    ],
+    text,
   };
 
   return sendMessage({ attachments: [attachments] });
 }
 
-export function sendMattermostMessagePullRequestReviewMessage({
+export function sendPullRequestReviewMattermostMessage({
   reviewers,
   repository,
   owner,
@@ -67,50 +59,35 @@ export function sendMattermostMessagePullRequestReviewMessage({
     .filter(v => v != null)
     .join(',');
 
+  const text = `*${repository}* > [${title}](${link})\n\n---\n\n${createMattermostMention(
+    owner
+  )}님이 ${reviewerNames}께 리뷰를 요청했어요.\n메이트가 리뷰로 인해 작업 진행을 못 하는 일이 없도록, 되도록이면 하루가 지나기 전에 리뷰를 부탁드려요!\n\n[지금 리뷰하기 :fire:](${link})`;
+
   const attachments: MattermostMessageAttachment = {
     fallback: `${repository}의 새로운 Pull Request가 오픈되었어요 :eyes:`,
     title: '새로운 Pull Request가 오픈되었어요 :eyes:',
-    text: `
-      *${repository}* > [${title}](${link})
-
-      ---
-
-      ${createMattermostMention(
-        owner
-      )}님이 ${reviewerNames}께 리뷰를 요청했어요\n메이트가 리뷰로 인해 작업 진행을 못 하는 일이 없도록, 되도록이면 하루가 지나기 전에 리뷰를 부탁드려요!
-    `,
-    actions: [
-      {
-        id: 'reviewPullRequest',
-        name: '지금 리뷰하기 :fire:',
-        integration: {
-          url: link,
-        },
-      },
-    ],
+    text,
   };
 
   return sendMessage({ attachments: [attachments] });
 }
 
-// export async function sendGithubPullRequestCommentMessage({
-//   pullRequest: { repository, link, title },
-//   comment,
-// }: {
-//   pullRequest: GithubPullRequest;
-//   comment: GithubPullRequestComment;
-// }) {
-//   const attachments: MattermostMessageAttachment = {
-//     fallback: `${repository}의 Pull Request에 새로운 댓글이 달렸어요`,
-//     title: 'Pull Request에 새로운 댓글이 달렸어요',
-//     text: `
-//       *${repository}* > [${title}](${link})
+export async function sendPullRequestCommentMattermostMessage({
+  pullRequest: { repository, link, title },
+  comment,
+}: {
+  pullRequest: GithubPullRequest;
+  comment: GithubPullRequestComment;
+}) {
+  const text = `*${repository}* > [${title}](${link})\n\n---\n\n${await replaceGithubUserToMattermostUserInString(
+    comment.message
+  )}`;
 
-//       ---
+  const attachments: MattermostMessageAttachment = {
+    fallback: `${repository}의 Pull Request에 새로운 댓글이 달렸어요`,
+    title: 'Pull Request에 새로운 댓글이 달렸어요',
+    text,
+  };
 
-//       ${await replaceGithubUserToSlackUserInString(comment.message)}
-//     `,
-//   };
-
-//   return sendMessage({ attachments: [attachments] });
-// }
+  return sendMessage({ attachments: [attachments] });
+}

--- a/src/utils/mattermost.ts
+++ b/src/utils/mattermost.ts
@@ -1,0 +1,116 @@
+import fetch from 'node-fetch';
+import { MATTERMOST_HOST } from './input';
+import { Developer } from '../models/developer';
+import { GithubPullRequest, GithubPullRequestReview } from '../models/github';
+import { MattermostMessageAttachment, MattermostMessageParams } from 'models/mattermost';
+
+export function createMattermostMention(developer: Developer) {
+  return developer.isExternalUser === true
+    ? developer.githubUserName
+    : `<@${developer.mattermostUserName ?? developer.githubUserName}>`;
+}
+
+export function sendMessage(args: MattermostMessageParams) {
+  return fetch(MATTERMOST_HOST, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      text: args.text,
+    }),
+  });
+}
+
+export function sendMattermostMessageReviewApprovedMessage({
+  pullRequest: { repository, link, title, owner },
+  review: { author },
+}: {
+  pullRequest: GithubPullRequest;
+  review: GithubPullRequestReview;
+}) {
+  const attachments: MattermostMessageAttachment = {
+    fallback: `${repository}의 Pull Request가 승인되었어요.`,
+    title: 'Pull Request가 승인되었어요! :white_check_mark:',
+    text: `
+      *${repository}* < [${title}](${link})
+
+      ---
+
+      ${createMattermostMention(author)}님이 ${createMattermostMention(
+      owner
+    )}님의 Pull Request를 승인했어요. 이제 머지하러가볼까요?
+    `,
+    actions: [
+      {
+        id: 'mergePullRequest',
+        name: '머지하러가기 :partymerge:',
+        integration: {
+          url: link,
+        },
+      },
+    ],
+  };
+
+  return sendMessage({ attachments: [attachments] });
+}
+
+export function sendMattermostMessagePullRequestReviewMessage({
+  reviewers,
+  repository,
+  owner,
+  link,
+  title,
+}: GithubPullRequest) {
+  const reviewerNames = reviewers
+    .map(reviewer => (reviewer ? `${createMattermostMention(reviewer)}님` : null))
+    .filter(v => v != null)
+    .join(',');
+
+  const attachments: MattermostMessageAttachment = {
+    fallback: `${repository}의 새로운 Pull Request가 오픈되었어요 :eyes:`,
+    title: '새로운 Pull Request가 오픈되었어요 :eyes:',
+    text: `
+      *${repository}* > [${title}](${link})
+
+      ---
+
+      ${createMattermostMention(
+        owner
+      )}님이 ${reviewerNames}께 리뷰를 요청했어요\n메이트가 리뷰로 인해 작업 진행을 못 하는 일이 없도록, 되도록이면 하루가 지나기 전에 리뷰를 부탁드려요!
+    `,
+    actions: [
+      {
+        id: 'reviewPullRequest',
+        name: '지금 리뷰하기 :fire:',
+        integration: {
+          url: link,
+        },
+      },
+    ],
+  };
+
+  return sendMessage({ attachments: [attachments] });
+}
+
+// export async function sendGithubPullRequestCommentMessage({
+//   pullRequest: { repository, link, title },
+//   comment,
+// }: {
+//   pullRequest: GithubPullRequest;
+//   comment: GithubPullRequestComment;
+// }) {
+//   const attachments: MattermostMessageAttachment = {
+//     fallback: `${repository}의 Pull Request에 새로운 댓글이 달렸어요`,
+//     title: 'Pull Request에 새로운 댓글이 달렸어요',
+//     text: `
+//       *${repository}* > [${title}](${link})
+
+//       ---
+
+//       ${await replaceGithubUserToSlackUserInString(comment.message)}
+//     `,
+//   };
+
+//   return sendMessage({ attachments: [attachments] });
+// }

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -14,7 +14,7 @@ export function sendMessage(args: ChatPostMessageArguments) {
   return slackClient.chat.postMessage(args);
 }
 
-export function sendMessageReviewApprovedMessage({
+export function sendSlackMessageReviewApprovedMessage({
   pullRequest: { repository, link, title, owner },
   review: { author },
 }: {
@@ -72,7 +72,13 @@ export function sendMessageReviewApprovedMessage({
   });
 }
 
-export function sendMessagePullRequestReviewMessage({ reviewers, repository, owner, link, title }: GithubPullRequest) {
+export function sendSlackMessagePullRequestReviewMessage({
+  reviewers,
+  repository,
+  owner,
+  link,
+  title,
+}: GithubPullRequest) {
   const reviewerNames = reviewers
     .map(reviewer => (reviewer ? `${createSlackMention(reviewer)}님` : null))
     .filter(v => v != null)
@@ -129,7 +135,7 @@ export function sendMessagePullRequestReviewMessage({ reviewers, repository, own
   });
 }
 
-export async function sendGithubPullRequestCommentMessage({
+export async function sendSlackGithubPullRequestCommentMessage({
   pullRequest: { repository, link, title },
   comment,
 }: {
@@ -138,11 +144,21 @@ export async function sendGithubPullRequestCommentMessage({
 }) {
   const blocks = [
     {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: 'Pull Request에 새로운 댓글이 달렸어요',
+      },
+    },
+    {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*${repository}* > <${link}|${title}> 풀리퀘스트에 새로운 댓글이 달렸어요`,
+        text: `*${repository}* > <${link}|${title}>`,
       },
+    },
+    {
+      type: 'divider',
     },
     {
       type: 'section',

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -14,7 +14,7 @@ export function sendMessage(args: ChatPostMessageArguments) {
   return slackClient.chat.postMessage(args);
 }
 
-export function sendSlackMessageReviewApprovedMessage({
+export function sendReviewApprovedSlackMessage({
   pullRequest: { repository, link, title, owner },
   review: { author },
 }: {
@@ -72,13 +72,7 @@ export function sendSlackMessageReviewApprovedMessage({
   });
 }
 
-export function sendSlackMessagePullRequestReviewMessage({
-  reviewers,
-  repository,
-  owner,
-  link,
-  title,
-}: GithubPullRequest) {
+export function sendPullRequestReviewSlackMessage({ reviewers, repository, owner, link, title }: GithubPullRequest) {
   const reviewerNames = reviewers
     .map(reviewer => (reviewer ? `${createSlackMention(reviewer)}님` : null))
     .filter(v => v != null)
@@ -135,7 +129,7 @@ export function sendSlackMessagePullRequestReviewMessage({
   });
 }
 
-export async function sendSlackGithubPullRequestCommentMessage({
+export async function sendPullRequestCommentSlackMessage({
   pullRequest: { repository, link, title },
   comment,
 }: {

--- a/test/mattermost.ts
+++ b/test/mattermost.ts
@@ -1,0 +1,65 @@
+import {
+  sendGithubPullRequestCommentMattermostMessage,
+  sendPullRequestReviewMattermostMessage,
+} from '../src/utils/mattermost';
+
+const main = async () => {
+  try {
+    await sendPullRequestReviewMattermostMessage({
+      title: '테스트 PR입니다',
+      body: '테스트테스트',
+      link: 'https://lubycon.io',
+      reviewers: [
+        {
+          name: '문동욱',
+          githubUserName: 'evan-moon',
+          slackUserId: 'U01810LSJ0L',
+          mattermostUserName: 'evan',
+        },
+      ],
+      owner: {
+        name: '문동욱',
+        githubUserName: 'evan-moon',
+        slackUserId: 'U01810LSJ0L',
+        mattermostUserName: 'evan',
+      },
+      repository: 'test-repository',
+    });
+    await sendGithubPullRequestCommentMattermostMessage({
+      pullRequest: {
+        title: '테스트 PR입니다',
+        body: '테스트테스트',
+        link: 'https://lubycon.io',
+        reviewers: [
+          {
+            name: '문동욱',
+            githubUserName: 'evan-moon',
+            slackUserId: 'U01810LSJ0L',
+            mattermostUserName: 'evan',
+          },
+        ],
+        owner: {
+          name: '문동욱',
+          githubUserName: 'evan-moon',
+          slackUserId: 'U01810LSJ0L',
+          mattermostUserName: 'evan',
+        },
+        repository: 'test-repository',
+      },
+      comment: {
+        author: {
+          name: '문동욱',
+          githubUserName: 'evan-moon',
+          slackUserId: 'U01810LSJ0L',
+          mattermostUserName: 'evan',
+        },
+        message: '안녕하세요. @evan-moon.',
+      },
+    });
+    console.log('Finished');
+  } catch (e) {
+    throw e;
+  }
+};
+
+main();

--- a/test/mattermost.ts
+++ b/test/mattermost.ts
@@ -1,5 +1,5 @@
 import {
-  sendGithubPullRequestCommentMattermostMessage,
+  sendPullRequestCommentMattermostMessage,
   sendPullRequestReviewMattermostMessage,
 } from '../src/utils/mattermost';
 
@@ -25,7 +25,7 @@ const main = async () => {
       },
       repository: 'test-repository',
     });
-    await sendGithubPullRequestCommentMattermostMessage({
+    await sendPullRequestCommentMattermostMessage({
       pullRequest: {
         title: '테스트 PR입니다',
         body: '테스트테스트',


### PR DESCRIPTION
Github Action이 트리거 되었을 때, 동일한 메세지를 슬랙 뿐 아니라 매터모스트에도 함께 보내도록 수정합니다.